### PR TITLE
Change how return url is determined for oauth

### DIFF
--- a/addons/auth_oauth/controllers/main.py
+++ b/addons/auth_oauth/controllers/main.py
@@ -56,7 +56,12 @@ class OAuthLogin(Home):
         except Exception:
             providers = []
         for provider in providers:
-            return_url = request.httprequest.url_root + 'auth_oauth/signin'
+            try:
+                #Patch: Werkzeug disregards X-Forwarded-Proto on nginx, so we must manually construct the URL
+                return_url = "%s://%s/auth_oauth/signin" % (request.httprequest.environ["HTTP_X_FORWARDED_PROTO"], request.httprequest.environ["HTTP_HOST"])
+            except:
+                #Fallback, as nginx may not be configured to pass X-Forwarded-Proto
+                return_url = request.httprequest.url_root + 'auth_oauth/signin'
             state = self.get_state(provider)
             params = dict(
                 response_type='token',


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Werkzeug does not take the http header "X-Forwarded-Proto" into account when determining the base url for oauth. This patch changes that.

Current behavior before PR:
The return URL was determined by using the standard werkzeug method for getting the request url, which could be incorrect running under a proxy

Desired behavior after PR is merged:
The correct return_url is determined

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
