### PR TITLE
Provide hook for altering the image picker dialogue

### DIFF
--- a/addons/web_editor/static/src/js/widgets.js
+++ b/addons/web_editor/static/src/js/widgets.js
@@ -1159,7 +1159,8 @@ return {
     'alt': alt,
     'MediaDialog': MediaDialog,
     'fontIcons': fontIcons,
-    'LinkDialog': LinkDialog
+    'LinkDialog': LinkDialog,
+    'ImageDialog': ImageDialog
 };
 
 });


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Cant hook into ImageDialog functions

Current behavior before PR:
Cant hook into ImageDialog functions

Desired behavior after PR is merged:
Can hook into ImageDialog functions

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
