### PR TITLE
[ENH] Cron Filter

### DIFF
--- a/odoo/addons/base/ir/ir_cron.py
+++ b/odoo/addons/base/ir/ir_cron.py
@@ -171,6 +171,11 @@ class ir_cron(models.Model):
 
     @classmethod
     def _acquire_job(cls, db_name):
+
+        cron_whitelist = odoo.tools.config.get("db_cron_whitelist", [])
+        if not db_name in cron_whitelist:
+            return False
+
         # TODO remove 'check' argument from addons/base_action_rule/base_action_rule.py
         """ Try to process one cron job.
 


### PR DESCRIPTION
new paramater in conf file - db_cron_whitelist - controls which dbs
the cron jobs can run on.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
