### PR TITLE
[FIX] Cache Copy Protected Records

### DIFF
--- a/odoo/api.py
+++ b/odoo/api.py
@@ -1060,6 +1060,11 @@ class Cache(object):
                         # because the other environment (eg. sudo()) is well expected to have access.
                         dst_field_cache[record_id] = value
 
+        for field in src._protected:
+            ids = dst._protected[field]
+            dst._protected[field] = ids.union(src._protected[field])
+
+
     def invalidate(self, spec=None):
         """ Invalidate the cache, partially or totally depending on ``spec``. """
         if spec is None:


### PR DESCRIPTION
When a "computed value A" relies on "computed value B" and
"computed value B" needs a related value (e.g. product.product from
product.template), then "_compute_related" in api.py will copy the cache if
the user is not superuser.

The cache is not copying the values in "_protected", causing
"modified_draft" in fields.py to incorrectly invalidate the cache for already
computed values which should be protected by their inclusion in "_protected".

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
