### PR TITLE
prevent whitelist errors during testing

### DIFF
--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -483,9 +483,6 @@ class IrMailServer(models.Model):
                  MailDeliveryException and logs root cause.
         """
 
-        if not db_whitelisted(self.env.cr.dbname):
-            raise UserError(_("Whitelist Error") + "\n" + _("Database cannot send emails as it is not on the whitelist."))
-
         # Use the default bounce address **only if** no Return-Path was
         # provided by caller.  Caller may be using Variable Envelope Return
         # Path (VERP) to detect no-longer valid email addresses.
@@ -522,6 +519,10 @@ class IrMailServer(models.Model):
         if getattr(threading.currentThread(), 'testing', False) or self.env.registry.in_test_mode():
             _test_logger.info("skip sending email in test mode")
             return message['Message-Id']
+
+        # Do not send mails if the DB is not whitelisted
+        if not db_whitelisted(self.env.cr.dbname):
+            raise UserError(_("Whitelist Error") + "\n" + _("Database cannot send emails as it is not on the whitelist."))
 
         try:
             message_id = message['Message-Id']


### PR DESCRIPTION
previously the first step in sending an email was to raise an exception if the db was not whitelisted, however this causes exceptions during unit testing if the tested code tries to send an email. Odoo already has a mechanism for preventing mailing during testing, so the db_whitelist check is moved to occur after that