### PR TITLE
temporary fix for stock move bom line issue from product _compute_average_price

### DIFF
--- a/addons/mrp_account/models/product.py
+++ b/addons/mrp_account/models/product.py
@@ -50,7 +50,7 @@ class ProductProduct(models.Model):
         dummy, bom_lines = bom.explode(self, 1)
         bom_lines = {line: data for line, data in bom_lines}
         value = 0
-        for move in stock_moves:
+        for move in stock_moves.filtered('bom_line_id'):
             bom_line = move.bom_line_id
             bom_line_data = bom_lines[bom_line]
             bom_line_qty = bom_line_data['qty']


### PR DESCRIPTION
There is an unsolved issue on mrp_account: stock move bom line issue from product _compute_average_price
I have replicated it by confirming a purchased order related to a sale

https://github.com/odoo/odoo/issues/70912
