### PR TITLE
PO update singleton issue fix

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -192,7 +192,7 @@ class PurchaseOrder(models.Model):
     def write(self, vals):
         res = super(PurchaseOrder, self).write(vals)
         if vals.get('date_planned'):
-            self.order_line.write({'date_planned': vals['date_planned']})
+            self.mapped('order_line').write({'date_planned': vals['date_planned']})
         return res
 
     @api.multi


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Issue when updating mass purchase orders

Current behavior before PR:
- Singleton issue when updating mass purchase orders

Desired behavior after PR is merged:
- Updating mass purchase orders successful




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
