### PR TITLE
Support for Pre_install Tests

### DIFF
--- a/odoo/modules/graph.py
+++ b/odoo/modules/graph.py
@@ -11,6 +11,11 @@ import odoo.tools as tools
 
 _logger = logging.getLogger(__name__)
 
+
+def check_package_delayed(info):
+    return int(info.get('load_priority', 0)) > 0
+
+
 class Graph(dict):
     """ Modules dependency graph.
 
@@ -20,8 +25,17 @@ class Graph(dict):
 
     def add_node(self, name, info):
         max_depth, father = 0, None
+
+        package_delayed = check_package_delayed(info)
+
         for d in info['depends']:
             n = self.get(d) or Node(d, self, None)  # lazy creation, do not use default value for get()
+
+            if package_delayed:
+                deepest_nodes = n.deepest_nodes()
+                if deepest_nodes:
+                    n = deepest_nodes[-1]
+
             if n.depth >= max_depth:
                 father = n
                 max_depth = n.depth
@@ -70,12 +84,30 @@ class Graph(dict):
         dependencies = dict([(p, info['depends']) for p, info in packages])
         current, later = set([p for p, info in packages]), set()
 
+        delayed_packages = []
+        do_delayed_package = False
+
         while packages and current > later:
             package, info = packages[0]
             deps = info['depends']
 
+            # Have we looped through all without adding anything?
+            if delayed_packages and package == delayed_packages[0][0]:
+                delayed_packages.sort(key=lambda p: int(p[1]['load_priority']))
+                do_delayed_package = delayed_packages[0][0]
+                delayed_packages = []
+
             # if all dependencies of 'package' are already in the graph, add 'package' in the graph
             if all(dep in self for dep in deps):
+                if check_package_delayed(info) and package != do_delayed_package:
+                    delayed_packages.append((package, info))
+                    packages.append((package, info))
+                    packages.pop(0)
+                    continue
+
+                delayed_packages = []
+                do_delayed_package = False
+
                 if not package in current:
                     packages.pop(0)
                     continue
@@ -151,6 +183,15 @@ class Node(object):
                 setattr(node, attr, True)
         self.children.sort(key=lambda x: x.name)
         return node
+
+    def deepest_nodes(self):
+        next_level = [self]
+        while next_level:
+            last_level = next_level
+            next_level = []
+            for node in last_level:
+                next_level.extend(node.children)
+        return last_level
 
     def __setattr__(self, name, value):
         super(Node, self).__setattr__(name, value)

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -176,6 +176,33 @@ def load_module_graph(cr, graph, status=None, perform_checks=True,
                 env = api.Environment(cr, SUPERUSER_ID, {})
                 env['base'].flush()
 
+        # Before Loading, check if any other modules have a "pre-install" test to be run
+        loader = odoo.tests.loader
+        updating = tools.config.options['init'] or tools.config.options['update']
+        test_results = None
+        if tools.config.options['test_enable'] and (needs_update or not updating):
+            env = api.Environment(cr, SUPERUSER_ID, {})
+
+            module_names = (sorted(registry._init_modules))
+            for test_module_name in module_names:
+                preinstalls = loader.find_pre_install_tests(test_module_name)
+                if module_name in preinstalls:
+                    _logger.info("Starting pre install tests")
+                    tests_before = registry._assertion_report.testsRun
+                    tests_t0, tests_q0 = time.time(), odoo.sql_db.sql_counter
+                    with odoo.api.Environment.manage():
+                        result = loader.run_suite(loader.make_suite(test_module_name, 'pre_install_%s' % module_name), test_module_name)
+                        registry._assertion_report.update(result)
+                    _logger.info(
+                        "%d pre-install-tests in %.2fs, %s queries",
+                        registry._assertion_report.testsRun - tests_before,
+                        time.time() - tests_t0,
+                        odoo.sql_db.sql_counter - tests_q0)
+
+                    # tests may have reset the environment
+                    env = api.Environment(cr, SUPERUSER_ID, {})
+        # End of pre-install tests
+
         load_openerp_module(package.name)
 
         new_install = package.state == 'to install'
@@ -286,6 +313,18 @@ def load_module_graph(cr, graph, status=None, perform_checks=True,
                 # tests may have reset the environment
                 env = api.Environment(cr, SUPERUSER_ID, {})
                 module = env['ir.module.module'].browse(module_id)
+
+            # If this module has pre-install tests, but that module is already installed,
+            # then we have either a circular reference, or need a load_priority in the
+            # manifest
+
+            preinstalls = loader.find_pre_install_tests(module_name)
+            loaded_modules = (sorted(registry._init_modules))
+            if any(n in loaded_modules for n in preinstalls):
+                _logger.error(
+                    "Module %s: Preinstall test not run as module already installed",
+                    module_name
+                )
 
         if needs_update:
             processed_modules.append(package.name)

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1277,6 +1277,15 @@ def preload_registries(dbnames):
                 module_names = (registry.updated_modules if update_module else
                                 sorted(registry._init_modules))
                 _logger.info("Starting post tests")
+
+                # Run pre_install tests which were missed because the module was never installed
+                for module_name in module_names:
+                    preinstalls = loader.find_pre_install_tests(module_name)
+                    for preinstall in preinstalls:
+                        if preinstall not in module_names:
+                            result = loader.run_suite(loader.make_suite(module_name, 'pre_install_%s' % preinstall), module_name)
+                            registry._assertion_report.update(result)
+
                 tests_before = registry._assertion_report.testsRun
                 result = loader.run_suite(loader.make_suite(module_names, 'post_install'))
                 registry._assertion_report.update(result)

--- a/odoo/tests/loader.py
+++ b/odoo/tests/loader.py
@@ -68,6 +68,20 @@ def make_suite(module_names, position='at_install'):
     )
     return OdooSuite(sorted(tests, key=lambda t: t.test_sequence))
 
+
+def find_pre_install_tests(module_name):
+    mods = get_test_modules(module_name)
+    pre_installs = set()
+    for mod in mods:
+        for test in unwrap_suite(unittest.TestLoader().loadTestsFromModule(mod)):
+            for tag in test.test_tags if hasattr(test, 'test_tags') else []:
+                if tag.startswith('+'):
+                    tag = tag.replace('+', '')
+                if tag.startswith('pre_install_'):
+                    pre_installs.add(tag.replace('pre_install_', ''))
+    return pre_installs
+
+
 def run_suite(suite, module_name=None):
     # avoid dependency hell
     from ..modules import module


### PR DESCRIPTION
Parsing and activation of pre_install tests before module install.

Parsing and activation of pre_install tests at end for modules not installed.

Delayed priority in module loads to ensure as much of tree installed as possible.