### PR TITLE
Support for Pre_install Tests

### DIFF
--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -185,6 +185,33 @@ def load_module_graph(cr, graph, status=None, perform_checks=True,
                 env = api.Environment(cr, SUPERUSER_ID, {})
                 env.flush_all()
 
+        # Before Loading, check if any other modules have a "pre-install" test to be run
+        loader = odoo.tests.loader
+        updating = tools.config.options['init'] or tools.config.options['update']
+        test_results = None
+        if tools.config.options['test_enable'] and (needs_update or not updating):
+            env = api.Environment(cr, SUPERUSER_ID, {})
+
+            module_names = (sorted(registry._init_modules))
+            for test_module_name in module_names:
+                preinstalls = loader.find_pre_install_tests(test_module_name)
+                if module_name in preinstalls:
+                    _logger.info("Starting pre install tests")
+                    tests_before = registry._assertion_report.testsRun
+                    tests_t0, tests_q0 = time.time(), odoo.sql_db.sql_counter
+                    with odoo.api.Environment.manage():
+                        result = loader.run_suite(loader.make_suite(test_module_name, 'pre_install_%s' % module_name), test_module_name)
+                        registry._assertion_report.update(result)
+                    _logger.info(
+                        "%d pre-install-tests in %.2fs, %s queries",
+                        registry._assertion_report.testsRun - tests_before,
+                        time.time() - tests_t0,
+                        odoo.sql_db.sql_counter - tests_q0)
+
+                    # tests may have reset the environment
+                    env = api.Environment(cr, SUPERUSER_ID, {})
+        # End of pre-install tests
+
         load_openerp_module(package.name)
 
         if new_install:
@@ -294,6 +321,18 @@ def load_module_graph(cr, graph, status=None, perform_checks=True,
                 # tests may have reset the environment
                 env = api.Environment(cr, SUPERUSER_ID, {})
                 module = env['ir.module.module'].browse(module_id)
+
+            # If this module has pre-install tests, but that module is already installed,
+            # then we have either a circular reference, or need a load_priority in the
+            # manifest
+
+            preinstalls = loader.find_pre_install_tests(module_name)
+            loaded_modules = (sorted(registry._init_modules))
+            if any(n in loaded_modules for n in preinstalls):
+                _logger.error(
+                    "Module %s: Preinstall test not run as module already installed",
+                    module_name
+                )
 
         if needs_update:
             processed_modules.append(package.name)

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1306,6 +1306,15 @@ def preload_registries(dbnames):
                 module_names = (registry.updated_modules if update_module else
                                 sorted(registry._init_modules))
                 _logger.info("Starting post tests")
+
+                # Run pre_install tests which were missed because the module was never installed
+                for module_name in module_names:
+                    preinstalls = loader.find_pre_install_tests(module_name)
+                    for preinstall in preinstalls:
+                        if preinstall not in module_names:
+                            result = loader.run_suite(loader.make_suite(module_name, 'pre_install_%s' % preinstall), module_name)
+                            registry._assertion_report.update(result)
+
                 tests_before = registry._assertion_report.testsRun
                 post_install_suite = loader.make_suite(module_names, 'post_install')
                 if post_install_suite.has_http_case():

--- a/odoo/tests/loader.py
+++ b/odoo/tests/loader.py
@@ -53,6 +53,20 @@ def make_suite(module_names, position='at_install'):
     )
     return OdooSuite(sorted(tests, key=lambda t: t.test_sequence))
 
+
+def find_pre_install_tests(module_name):
+    mods = get_test_modules(module_name)
+    pre_installs = set()
+    for mod in mods:
+        for test in unwrap_suite(unittest.TestLoader().loadTestsFromModule(mod)):
+            for tag in test.test_tags if hasattr(test, 'test_tags') else []:
+                if tag.startswith('+'):
+                    tag = tag.replace('+', '')
+                if tag.startswith('pre_install_'):
+                    pre_installs.add(tag.replace('pre_install_', ''))
+    return pre_installs
+
+
 def run_suite(suite, module_name=None):
     # avoid dependency hell
     from ..modules import module


### PR DESCRIPTION
Parsing and activation of pre_install tests before module install.

Parsing and activation of pre_install tests at end for modules not installed.

Delayed priority in module loads to ensure as much of tree installed as possible.