### PR TITLE
Patches related to unit tests

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -24,7 +24,10 @@ class AccountTestInvoicingCommon(SavepointCase):
     def setUpClass(cls, chart_template_ref=None):
         super(AccountTestInvoicingCommon, cls).setUpClass()
 
-        assert 'post_install' in cls.test_tags, 'This test requires a CoA to be installed, it should be tagged "post_install"'
+        assert (
+            'post_install' in cls.test_tags
+            or any([t.startswith("pre_install_") for t in cls.test_tags])
+        ), 'This test requires a CoA to be installed, it should be tagged "post_install" or "pre_install_MODULE_NAME"'
 
         if chart_template_ref:
             chart_template = cls.env.ref(chart_template_ref)

--- a/odoo/tests/runner.py
+++ b/odoo/tests/runner.py
@@ -96,7 +96,13 @@ class OdooTestResult(unittest.result.TestResult):
 
     def addSkip(self, test, reason):
         super().addSkip(test, reason)
-        self.log(logging.INFO, 'skipped %s', self.getDescription(test), test=test)
+        self.log(
+            logging.INFO,
+            'skipped %(description)s - Reason: %(reason)s', {
+                "description": self.getDescription(test), "reason": reason
+            },
+            test=test
+        )
 
     def addUnexpectedSuccess(self, test):
         super().addUnexpectedSuccess(test)


### PR DESCRIPTION
- Bypass the requirement to tag accounting tests with "post_install" if the "pre_install" mechanism is being used.
- Record the reason in the log if a test is skipped