### PR TITLE
[14.0][FIX] fleet,product_margin,resource: Avoid using write on compute methods

### DIFF
--- a/addons/product_margin/models/product_product.py
+++ b/addons/product_margin/models/product_product.py
@@ -166,5 +166,5 @@ class ProductProduct(models.Model):
             res[product.id]['purchase_gap'] = res[product.id]['normal_cost'] - res[product.id]['total_cost']
             res[product.id]['expected_margin'] = res[product.id].get('sale_expected', 0.0) - res[product.id]['normal_cost']
             res[product.id]['expected_margin_rate'] = res[product.id].get('sale_expected', 0.0) and res[product.id]['expected_margin'] * 100 / res[product.id].get('sale_expected', 0.0) or 0.0
-            product.write(res[product.id])
+            product.update(res[product.id])
         return res

--- a/addons/resource/models/resource.py
+++ b/addons/resource/models/resource.py
@@ -217,7 +217,7 @@ class ResourceCalendar(models.Model):
     def _compute_attendance_ids(self):
         for calendar in self.filtered(lambda c: not c._origin or c._origin.company_id != c.company_id):
             company_calendar = calendar.company_id.resource_calendar_id
-            calendar.write({
+            calendar.update({
                 'two_weeks_calendar': company_calendar.two_weeks_calendar,
                 'hours_per_day': company_calendar.hours_per_day,
                 'tz': company_calendar.tz,
@@ -228,7 +228,7 @@ class ResourceCalendar(models.Model):
     @api.depends('company_id')
     def _compute_global_leave_ids(self):
         for calendar in self.filtered(lambda c: not c._origin or c._origin.company_id != c.company_id):
-            calendar.write({
+            calendar.update({
                 'global_leave_ids': [(5, 0, 0)] + [
                     (0, 0, leave._copy_leave_vals()) for leave in calendar.company_id.resource_calendar_id.global_leave_ids]
             })


### PR DESCRIPTION
Backport from 16.0 https://github.com/odoo/odoo/commit/5f18f068e62ba6cf6296c5f818b2cdfabed1fdfb

The write call in product.product is the cause of some UPDATE queries being triggered on reads on at least 1 customer deployment, probably many.

Purpose
=======

Onchange methods are executed in "edit-mode", so you need to save to get the definitive values saved on the DB, but if you do a write on it, that changes are immediately saved to the DB, so if you discard the changes on UI, you will have inconsistent data. That's why you have to do update instead, that only modifies the temporary dataset.

Courtesy of https://github.com/OCA/pylint-odoo/issues/356

closes odoo/odoo#104419

Taskid: 3046426
Related: odoo/enterprise#33366