### PR TITLE
[IMP] orm: introduce Field.compute_sql

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -15,7 +15,7 @@ from datetime import timedelta
 from dateutil.parser import parse
 
 from odoo import _, api, fields, models, modules, SUPERUSER_ID, tools
-from odoo.addons.base.models.ir_mail_server import MailDeliveryException
+from odoo.addons.base.models.ir_mail_server import MailDeliveryException, MailDeliveryWhitelistException
 from odoo.exceptions import UserError, ValidationError
 from odoo.modules.registry import Registry
 from odoo.addons.base.models.ir_cron import db_whitelisted
@@ -724,6 +724,8 @@ class MailMail(models.Model):
             smtp_session = None
             try:
                 smtp_session = self.env['ir.mail_server']._connect__(mail_server_id=mail_server_id, smtp_from=smtp_from)
+            except MailDeliveryWhitelistException:
+                pass
             except Exception as exc:
                 if raise_exception:
                     # To be consistent and backward compatible with mail_mail.send() raised

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -11,6 +11,8 @@ from odoo.fields import Domain
 from odoo.tools import is_html_empty
 from odoo.tools.safe_eval import safe_eval, time
 
+from odoo.addons.base.models.ir_cron import db_whitelisted
+
 _logger = logging.getLogger(__name__)
 
 
@@ -688,6 +690,11 @@ class MailTemplate(models.Model):
 
         # Grant access to send_mail only if access to related document
         self.ensure_one()
+
+        if force_send and raise_exception and not db_whitelisted(self.env.cr.dbname):
+            # Allows auto functions, like create users, to continue without failing
+            raise_exception = False
+
         return self.send_mail_batch(
             [res_id],
             force_send=force_send,

--- a/addons/web/static/src/views/view_service.js
+++ b/addons/web/static/src/views/view_service.js
@@ -94,10 +94,22 @@ export const viewService = {
             //         ([k, v]) => k == "lang" || k.endsWith("_view_ref")
             //     )
             // );
+            //
+            // If we have a view_context, we keep any keys listed in it.
             const filteredContext = Object.fromEntries(
-                Object.entries(context || {}).filter(
-                    ([k, v]) => k == "lang" || k.endsWith("_view_ref") || k == "orchestrate_model"
-                )
+                Object.entries(context || {}).filter(([k, v]) => {
+                    // Always keep these keys
+                    if (k === "lang" || k.endsWith("_view_ref")) {
+                        return true;
+                    }
+
+                    // Dynamically keep keys listed in context.view_context (if it's a list)
+                    if (Array.isArray(context?.view_context) && context.view_context.includes(k)) {
+                        return true;
+                    }
+
+                    return false;
+                })
             );
 
             const result = await orm.cache({ type: "disk" }).call(resModel, "get_views", [], {

--- a/addons/web/static/src/views/view_service.js
+++ b/addons/web/static/src/views/view_service.js
@@ -89,9 +89,14 @@ export const viewService = {
             if (env.debug) {
                 loadViewsOptions.debug = true;
             }
+            // const filteredContext = Object.fromEntries(
+            //     Object.entries(context || {}).filter(
+            //         ([k, v]) => k == "lang" || k.endsWith("_view_ref")
+            //     )
+            // );
             const filteredContext = Object.fromEntries(
                 Object.entries(context || {}).filter(
-                    ([k, v]) => k == "lang" || k.endsWith("_view_ref")
+                    ([k, v]) => k == "lang" || k.endsWith("_view_ref") || k == "orchestrate_model"
                 )
             );
 

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -14,7 +14,7 @@ import psycopg2.errors
 from dateutil.relativedelta import relativedelta
 
 import json
-import re
+from functools import lru_cache
 
 import odoo
 from odoo import api, fields, models, sql_db
@@ -45,14 +45,16 @@ MIN_DELTA_BEFORE_DEACTIVATION = timedelta(days=7)
 ODOO_NOTIFY_FUNCTION = os.getenv('ODOO_NOTIFY_FUNCTION', 'pg_notify')
 
 
+@lru_cache(maxsize=64)
 def db_whitelisted(db_name):
-    cron_whitelist = odoo.tools.config.get("db_cron_whitelist") and json.loads(odoo.tools.config["db_cron_whitelist"]) or []
+    cron_whitelist = odoo.tools.config.get("db_cron_whitelist") or []
+
+    # temporary code only until runbot is changed to pass unquoted db names
+    if len(cron_whitelist) == 1 and type(first_element := json.loads(cron_whitelist[0])) == list:
+        cron_whitelist = first_element
+
     if db_name not in cron_whitelist:
-        for cw_name in cron_whitelist:
-            if re.match(cw_name, db_name):
-                break
-        else:
-            return False
+        return False
     return True
 
 class BadVersion(Exception):

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -13,6 +13,10 @@ import psycopg2
 import psycopg2.errors
 from dateutil.relativedelta import relativedelta
 
+import json
+import re
+
+import odoo
 from odoo import api, fields, models, sql_db
 from odoo.exceptions import LockError, UserError
 from odoo.http import serialize_exception
@@ -40,6 +44,16 @@ MIN_DELTA_BEFORE_DEACTIVATION = timedelta(days=7)
 # custom function to call instead of default PostgreSQL's `pg_notify`
 ODOO_NOTIFY_FUNCTION = os.getenv('ODOO_NOTIFY_FUNCTION', 'pg_notify')
 
+
+def db_whitelisted(db_name):
+    cron_whitelist = odoo.tools.config.get("db_cron_whitelist") and json.loads(odoo.tools.config["db_cron_whitelist"]) or []
+    if db_name not in cron_whitelist:
+        for cw_name in cron_whitelist:
+            if re.match(cw_name, db_name):
+                break
+        else:
+            return False
+    return True
 
 class BadVersion(Exception):
     pass
@@ -185,6 +199,10 @@ class IrCron(models.Model):
 
     @staticmethod
     def _process_jobs(db_name: str) -> None:
+
+        if not db_whitelisted(db_name):
+            return False
+
         """ Execute every job ready to be run on this database. """
         try:
             db = sql_db.db_connect(db_name)

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -14,6 +14,7 @@ import psycopg2.errors
 from dateutil.relativedelta import relativedelta
 
 import json
+import re
 from functools import lru_cache
 
 import odoo
@@ -54,6 +55,9 @@ def db_whitelisted(db_name):
         cron_whitelist = first_element
 
     if db_name not in cron_whitelist:
+        for pattern in cron_whitelist:
+            if re.match(pattern, db_name):
+                return True
         return False
     return True
 

--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -11,6 +11,9 @@ import ssl
 from email.message import EmailMessage
 from email.parser import BytesParser
 from email.utils import make_msgid
+import threading
+import os
+
 from socket import gaierror, timeout
 
 import idna
@@ -66,6 +69,10 @@ SMTP_TIMEOUT = 60
 
 class MailDeliveryException(Exception):
     """Specific exception subclass for mail delivery errors"""
+
+
+class MailDeliveryWhitelistException(MailDeliveryException):
+    """Specific exception subclass for non whitelisted mail delivery attempts"""
 
 
 # Python 3: patch SMTP's internal printer/debugger
@@ -514,6 +521,8 @@ class IrMail_Server(models.Model):
                 "or provide the SMTP parameters explicitly.",
             ))
 
+        self._is_allowed_to_send(smtp_server, raise_exception=True)
+
         if smtp_encryption in ('ssl', 'ssl_strict'):
             connection = smtplib.SMTP_SSL(smtp_server, smtp_port, timeout=SMTP_TIMEOUT, context=ssl_context)
         else:
@@ -849,14 +858,6 @@ class IrMail_Server(models.Model):
             _test_logger.debug("skip sending email in test mode")
             return message['Message-Id']
 
-        # Some odoo tests in base explicitly patch ir.mail_server to return False from _is_test_mode()
-        if (
-            not db_whitelisted(self.env.cr.dbname)
-            and not isinstance(self.connect, MagicMock)
-            and smtp.__class__.__name__ != "FakeSMTP"
-        ):
-            raise UserError(_("Whitelist Error") + "\n" + _("Database cannot send emails as it is not on the whitelist."))
-
         try:
             message_id = message['Message-Id']
 
@@ -866,6 +867,8 @@ class IrMail_Server(models.Model):
             if not smtp_session:
                 smtp.quit()
         except smtplib.SMTPServerDisconnected:
+            raise
+        except MailDeliveryWhitelistException:
             raise
         except Exception as e:
             msg = _(
@@ -1000,3 +1003,52 @@ class IrMail_Server(models.Model):
         else:
             self.smtp_port = 25
         return result
+
+    def _is_test_mode(self):
+        """Return True if we are running the tests, so we do not send real emails.
+
+        Can be overridden in tests after mocking the SMTP lib to test in depth the
+        outgoing mail server.
+        """
+        return getattr(threading.current_thread(), 'testing', False) or self.env.registry.in_test_mode()
+
+    def _is_allowed_to_send(self, smtp_server: str = None, raise_exception: bool = False) -> bool:
+        """
+        Return True if the database is allowed to send email.
+
+        Emails are not allowed unless the database is whitelisted by using the
+        `db_cron_whitelist` option in the odoo config file.
+
+        During development, we don't want to enable this option, and we do not want
+        to send emails to real users, but we do want to test emails using local
+        development mail servers such as MailHog.
+
+        To avoid accidentally allowing real local email servers such as postfix
+        to send emails, the mail server must be explicitly configured with the
+        environment variable `ODOO_DEV_SMTP_SERVER` if the database is not
+        whitelisted.
+        """
+
+        if db_whitelisted(self.env.cr.dbname):
+            return True
+
+        # Some odoo tests in base explicitly patch ir.mail_server to return False from
+        # _is_test_mode() in which case we want to allow sending mails.
+        if isinstance(self.connect, MagicMock):
+            return True
+
+        dev_smtp_server = os.environ.get("ODOO_DEV_SMTP_SERVER")
+        if dev_smtp_server in ["localhost", "127.0.0.1"] and (
+            (smtp_server and smtp_server == dev_smtp_server)
+            or (len(self) <= 1 and self.smtp_host == dev_smtp_server)
+        ):
+            _logger.info("Allowing local development SMTP server: %s", smtp_server)
+            return True
+
+        msg = _("Database cannot send emails as it is not on the whitelist.")
+        _logger.warning(msg)
+
+        if raise_exception:
+            raise MailDeliveryWhitelistException(msg)
+
+        return False

--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -55,6 +55,9 @@ except ImportError:
     # urllib3 1.25 and below
     from urllib3.packages.ssl_match_hostname import CertificateError, match_hostname
 
+from odoo.addons.base.models.ir_cron import db_whitelisted
+from unittest.mock import MagicMock
+
 _logger = logging.getLogger(__name__)
 _test_logger = logging.getLogger('odoo.tests')
 
@@ -845,6 +848,14 @@ class IrMail_Server(models.Model):
         if self._disable_send():
             _test_logger.debug("skip sending email in test mode")
             return message['Message-Id']
+
+        # Some odoo tests in base explicitly patch ir.mail_server to return False from _is_test_mode()
+        if (
+            not db_whitelisted(self.env.cr.dbname)
+            and not isinstance(self.connect, MagicMock)
+            and smtp.__class__.__name__ != "FakeSMTP"
+        ):
+            raise UserError(_("Whitelist Error") + "\n" + _("Database cannot send emails as it is not on the whitelist."))
 
         try:
             message_id = message['Message-Id']

--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -11,7 +11,6 @@ import ssl
 from email.message import EmailMessage
 from email.parser import BytesParser
 from email.utils import make_msgid
-import threading
 import os
 
 from socket import gaierror, timeout
@@ -1004,14 +1003,6 @@ class IrMail_Server(models.Model):
             self.smtp_port = 25
         return result
 
-    def _is_test_mode(self):
-        """Return True if we are running the tests, so we do not send real emails.
-
-        Can be overridden in tests after mocking the SMTP lib to test in depth the
-        outgoing mail server.
-        """
-        return getattr(threading.current_thread(), 'testing', False) or self.env.registry.in_test_mode()
-
     def _is_allowed_to_send(self, smtp_server: str = None, raise_exception: bool = False) -> bool:
         """
         Return True if the database is allowed to send email.
@@ -1034,7 +1025,7 @@ class IrMail_Server(models.Model):
 
         # Some odoo tests in base explicitly patch ir.mail_server to return False from
         # _is_test_mode() in which case we want to allow sending mails.
-        if isinstance(self.connect, MagicMock):
+        if isinstance(self._connect__, MagicMock):
             return True
 
         dev_smtp_server = os.environ.get("ODOO_DEV_SMTP_SERVER")

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -396,6 +396,26 @@ def db_filter(dbs, host=None):
     :rtype: List[str]
     """
 
+    if config.get('db_filter_multi'):
+        host_m = host
+
+        if host_m is None:
+            host_m = request.httprequest.environ.get('HTTP_HOST', '')
+        host_m = host_m.partition(':')[0]
+        if host_m.startswith('www.'):
+            host_m = host_m[4:]
+        domain = host_m.partition('.')[0]
+
+        db_dict = json.loads(config["db_filter_multi"])
+        if isinstance(db_dict, dict) and host_m in db_dict:
+            ndbs = []
+            for dbfilter in db_dict[host_m]:
+                dbfilter_re = re.compile(
+                    dbfilter.replace("%h", re.escape(host_m))
+                    .replace("%d", re.escape(domain)))
+                ndbs.extend([db for db in dbs if dbfilter_re.match(db)])
+            return sorted(list(set(ndbs)))
+
     if config['dbfilter']:
         #        host
         #     -----------

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -406,7 +406,11 @@ def db_filter(dbs, host=None):
             host_m = host_m[4:]
         domain = host_m.partition('.')[0]
 
-        db_dict = json.loads(config["db_filter_multi"])
+        try:
+            db_dict = json.loads(config["db_filter_multi"])
+        except (json.JSONDecodeError, ValueError):
+            _logger.error("db_filter_multi config is not valid JSON, ignoring")
+            db_dict = {}
         if isinstance(db_dict, dict) and host_m in db_dict:
             ndbs = []
             for dbfilter in db_dict[host_m]:

--- a/odoo/modules/module_graph.py
+++ b/odoo/modules/module_graph.py
@@ -261,7 +261,7 @@ class ModuleGraph:
                 try:
                     module.depends = OrderedSet(self._modules[dep] for dep in depends)
                 except KeyError:
-                    _logger.info('module %s: some depends are not loaded, skipped', name)
+                    _logger.warning('module %s: some depends are not loaded, skipped', name)
                     self._remove(name)
 
     def _update_depth(self, names: Iterable[str]) -> None:

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -393,6 +393,8 @@ class configmanager:
                          help="specify the maximum number of physical connections to PostgreSQL specifically for the gevent worker")
         group.add_option("--db-template", dest="db_template", my_default="template0", env_name='PGDATABASE_TEMPLATE',
                          help="specify a custom database template to create a new database")
+        group.add_option("--db-cron-whitelist", dest="db_cron_whitelist", type='comma', my_default=[],
+                         help="specify databases which are whitelisted for running crons and sending emails")
         parser.add_option_group(group)
 
         # i18n Group

--- a/odoo/tools/template_inheritance.py
+++ b/odoo/tools/template_inheritance.py
@@ -241,7 +241,7 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
                     unknown = [
                         key
                         for key in child.attrib
-                        if key not in ('name', 'add', 'remove', 'separator')
+                        if key not in ('name', 'add', 'remove', 'separator', 'add_to_dict')
                         and not key.startswith('data-oe-')
                     ]
                     if unknown:
@@ -254,6 +254,8 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
                     value = None
 
                     if child.get('add') or child.get('remove'):
+                        if child.get('add_to_dict'):
+                            raise ValueError(_('Cannot add to dictionary using add or remove'))
                         if child.text:
                             raise ValueError(_lt(
                                 "Element <attribute> with 'add' or 'remove' cannot contain text %s",
@@ -302,6 +304,12 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
                                 (v for v in values if v and v not in to_remove),
                                 to_add
                             ))
+                    elif child.get('add_to_dict'):
+                        value = node.get(attribute, '{}').strip(' \n')
+                        if not value.startswith('{') or not value.endswith('}'):
+                            raise ValueError(_(f'Cannot add to value which is not dictionary {value}'))
+                        value = value.strip(' {},\n')
+                        value = '{%s%s}' % (value + ', ' if value else '', child.get('add_to_dict'))
                     else:
                         value = child.text or ''
 

--- a/odoo/tools/template_inheritance.py
+++ b/odoo/tools/template_inheritance.py
@@ -307,7 +307,7 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
                     elif child.get('add_to_dict'):
                         value = node.get(attribute, '{}').strip(' \n')
                         if not value.startswith('{') or not value.endswith('}'):
-                            raise ValueError(_(f'Cannot add to value which is not dictionary {value}'))
+                            raise ValueError(_('Cannot add to value which is not dictionary %s') % value)
                         value = value.strip(' {},\n')
                         value = '{%s%s}' % (value + ', ' if value else '', child.get('add_to_dict'))
                     else:


### PR DESCRIPTION
The same way we have a `compute` function, we can make a `compute_sql` function which will replace overides of `Model._field_to_sql`. Once defined, we will be able to group or sort in SQL by that field.

If we have a `_compute_sql`, we must explicitely specify the `compute_sudo` flag to define what we expect (instead of relying on the default value). The method should do the same think as the `compute` method, but in SQL.

Part-of: odoo/odoo#221544
Related: odoo/enterprise#91523

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
